### PR TITLE
Fix issues #1 and #2

### DIFF
--- a/kic_crawler.py
+++ b/kic_crawler.py
@@ -41,6 +41,9 @@ def get_pinned(soup):
             new_icon.decompose()
         title = notice.find('div', {'class':'kboard-default-cut-strings'}).get_text().strip()
         date = notice.find('td', {'class':'kboard-list-date'}).get_text().strip()
+        if ((len(date) == 5) or (len(date) < 5)):
+            date = datetime.date.today()
+            date = date.strftime("%Y.%m.%d")
         links = notice.find_all('a')
         for a in links:
             if a.has_attr('href'):
@@ -60,6 +63,9 @@ def get_normal(soup):
         try:
             title = notice.find('div', {'class':'kboard-default-cut-strings'}).get_text().strip()
             date = notice.find('td', {'class':'kboard-list-date'}).get_text().strip()
+            if ((len(date) == 5) or (len(date) < 5)):
+                date = datetime.date.today()
+                date = date.strftime("%Y.%m.%d")
             links = notice.find_all('a')
             for a in links:
                 if a.has_attr('href'):
@@ -69,7 +75,7 @@ def get_normal(soup):
         except:
             pass
     return new_normal
-    
+
 def url_mod(short_link):
     '''
     This function modifies the given short URL to match/become the full URL.
@@ -175,7 +181,7 @@ for category in [undergraduate, jna, scholarships, others]:
                 notice_date = new_pinned[short_link]['notice_date']
                 crawl_dt = datetime.datetime.now()
                 title = new_pinned[short_link]['notice_title']
-                
+
                 text_part = notice_date + '\n' + title
                 full_url = shorten_url(url_mod(short_link))
                 final_notice = '#중요_공지\n' + f'<code>{text_part}</code>' + '\n' + full_url
@@ -207,7 +213,7 @@ for category in [undergraduate, jna, scholarships, others]:
                 notice_date = new_normal[short_link]['notice_date']
                 crawl_dt = datetime.datetime.now()
                 title = new_normal[short_link]['notice_title']
-                
+
                 text_part = notice_date + '\n' + title
                 full_url = shorten_url(url_mod(short_link))
                 final_notice = f'<code>{text_part}</code>' + '\n' + full_url
@@ -233,4 +239,8 @@ for category in [undergraduate, jna, scholarships, others]:
         try:
             response.raise_for_status()
         except r.exceptions.HTTPError as e:
-            msg_admin(f'CRAWLING FAILED!\n{e}')
+            if response.status_code == 502:
+                pass
+            else:
+                msg_admin(f'CRAWLING FAILED!\n{e}')
+            time.sleep(300)


### PR DESCRIPTION
#1 과 #2 를 해결함.

첫번째 문제는 처음 접속 에러 발생 시 5분 동안 크롤러가 작동하지 않도록 함.
사용 중인 Linux 계열 서버에서 "flock -xn /usr/bin/flock /PATH/TO/kic.lock /usr/bin/python3 /PATH/TO/kic-crawler.py"로 crontab 실행 스크립트를 수정함으로써 크롤러의 5분 휴식기 중 중복 인스턴스가 실행되지 않도록 함.

첫번째 문제의 해결에 부가해, 학교 프런트 엔드 서버의 재부팅은 매일 정해진 시각에 반드시 발생하므로 관련 HTTP Error인 502 에러는 관리자 경고를 건너뛰고 크롤러가 바로 휴식기에 진입하도록 함.

두번째 문제는 공지 사항 등록 일자를 크롤링한 뒤 글자수가 일정 수 이하일 경우 datetime 모듈이 당일 날짜를 불러와 형식에 맞게 수정하고 앞선 크롤링 내용을 대체하도록 수정함.